### PR TITLE
reenable cuda compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,6 @@ endif(GDAL_FOUND)
 option(WITH_CUDA "Compile with CUDA support" ON)
 if(NOT APPLE AND WITH_CUDA)
 find_package( CUDA )
-set(CUDA_FOUND false)
 if(CUDA_FOUND)
   message(STATUS "Found CUDA")
     include_directories(${CUDA_INCLUDE_DIRS})
@@ -443,17 +442,19 @@ option(WITH_KINFU "Compile LVR Kinfu" OFF)
 # compatible to gcc4.8. Older CUDA versions require GCC lower
 # than 4.8
 ###############################################################################
-if(CUDA_FOUND AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
-              AND CUDA_VERSION VERSION_GREATER 8
-              AND CUDA_VERSION VERSION_LESS 10)
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5 )
-        message(STATUS "******************************************************************")
-        message(STATUS "* Your gcc version needs to be lower than 6 to compile the LVR   *")
-        message(STATUS "* CUDA library and apps with CUDA. Setting CUDA_HOST_COMPILER to *")
-        message(STATUS "* g++-6*. Please ensure that g++ 6 is installed on your system.  *")
-        message(STATUS "******************************************************************")
-        set(CUDA_HOST_COMPILER "g++-6" CACHE STRING "" FORCE)
-        endif()
+if(CUDA_FOUND)
+  include(max_cuda_gcc_version)
+  max_cuda_gcc_version(CUDA_VERSION MAX_CUDA_GCC_VERSION)
+  message(STATUS "Highest supported GCC version for CUDA: ${MAX_CUDA_GCC_VERSION}")
+
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER ${MAX_CUDA_GCC_VERSION})
+    message(STATUS "******************************************************************")
+    message(STATUS "* Your gcc version needs to be lower than or equal ${MAX_CUDA_GCC_VERSION} to compile  *")
+    message(STATUS "* the CUDA library and apps. Setting CUDA_HOST_COMPILER to       *")
+    message(STATUS "* g++-${MAX_CUDA_GCC_VERSION}. Please ensure that g++-${MAX_CUDA_GCC_VERSION} is installed on your system.   *")
+    message(STATUS "******************************************************************")
+    set(CUDA_HOST_COMPILER "g++-${MAX_CUDA_GCC_VERSION}" CACHE STRING "" FORCE)
+  endif()
 endif()
 
 if(CUDA_FOUND AND "${OpenCV_VERSION_PATCH}" VERSION_GREATER "8" AND WITH_KINFU)

--- a/CMakeModules/max_cuda_gcc_version.cmake
+++ b/CMakeModules/max_cuda_gcc_version.cmake
@@ -1,0 +1,51 @@
+# CUDA GCC Compatibility
+# See here: https://stackoverflow.com/questions/6622454/cuda-incompatible-with-my-gcc-version
+
+# CUDA version                max GCC version
+# 11.4.1+, 11.5	                     11
+# 11.1, 11.2, 11.3, 11.4.0	         10
+# 11	                                9
+# 10.1, 10.2	                        8
+# 9.2, 10.0	                          7
+# 9.0, 9.1	                          6
+# 8	                                  5.3
+# 7	                                  4.9
+# 5.5, 6	                            4.8
+# 4.2, 5	                            4.6
+# 4.1	                                4.5
+# 4.0	                                4.4
+
+# Usage: 
+# max_cuda_gcc_version(CUDA_VERSION MAX_CUDA_GCC_VERSION)
+# message(STATUS "Maximum allowed gcc version for cuda is: ${MAX_CUDA_GCC_VERSION}")
+function(max_cuda_gcc_version _CUDA_VERSION _MAX_GCC_VERSION)
+
+if(${_CUDA_VERSION} VERSION_GREATER_EQUAL 12.0.0)
+  set(${_MAX_GCC_VERSION} 12 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 11.4.0)   # 11.4.1+, 11.5  -> 11
+  set(${_MAX_GCC_VERSION} 11 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 11.0) # 11.1, 11.2, 11.3, 11.4.0 -> 10
+  set(${_MAX_GCC_VERSION} 10 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 10.2) # 11	       -> 9
+  set(${_MAX_GCC_VERSION} 9 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 10.0) # 10.1 10.2 -> 8
+  set(${_MAX_GCC_VERSION} 8 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 9.1)  # 9.2 10.0 -> 7
+  set(${_MAX_GCC_VERSION} 7 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 8)    # 9.0 9.1 -> 6
+  set(${_MAX_GCC_VERSION} 6 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 7)    # 8 -> 5.3
+  set(${_MAX_GCC_VERSION} 5.3 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 6)    # 7 -> 4.9
+  set(${_MAX_GCC_VERSION} 4.9 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 5.4)  # 5.5  6 -> 4.8
+  set(${_MAX_GCC_VERSION} 4.8 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 4.1)  # 4.2 5 -> 4.6
+  set(${_MAX_GCC_VERSION} 4.6 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 4.0)  # 4.1 -> 4.5
+  set(${_MAX_GCC_VERSION} 4.5 PARENT_SCOPE)
+elseif(${_CUDA_VERSION} VERSION_GREATER 3)    # 4.0 -> 4.4
+  set(${_MAX_GCC_VERSION} 4.4 PARENT_SCOPE)
+endif()
+
+endfunction()


### PR DESCRIPTION
I added a cmake script that determines the maximum allowed gcc version for a certain cuda version
-> The lvr_cuda library can be compiled again